### PR TITLE
Multiple blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,38 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Dotclear is an open-source web publishing software.
 Take control over your blog!
 
-Dotclear project's purpose is to provide a user-friendly
-tool allowing anyone to publish on the web, regardless of their technical skills.
-
-### Features
-
-- Easy publication
-- Fully customizable theme
-- User-friendly administration
-- Flexible template system
-- Media management
-- Choose from several editing syntax (wiki, markdown or directly in wysiwyg)
-- Flexible comment system
-- Built-in antispam
-- Localization
-- Presentation widgets
-- Themes and plugins
-- Pages
-- Tags and categories
-- Automated installation
-- Support for several database types
-- Multiblog
-- Multi-user with permissions
-- Standards compliant
-- Accessible
-- Importing / exporting
-- Naturally optimized for search engines
-- Syndication feeds
-- Complete trackback/pingback/webmention support
-- Full Unicode support
-- Extensible
-- Performance and scalability
-- Twice free
+Dotclear project's purpose is to provide a user-friendly tool allowing anyone to publish on the web, regardless of their technical skills.
 
 
 **Shipped version:** 2.27.3~ynh1

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,38 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Dotclear is an open-source web publishing software.
 Take control over your blog!
 
-Dotclear project's purpose is to provide a user-friendly
-tool allowing anyone to publish on the web, regardless of their technical skills.
-
-### Features
-
-- Easy publication
-- Fully customizable theme
-- User-friendly administration
-- Flexible template system
-- Media management
-- Choose from several editing syntax (wiki, markdown or directly in wysiwyg)
-- Flexible comment system
-- Built-in antispam
-- Localization
-- Presentation widgets
-- Themes and plugins
-- Pages
-- Tags and categories
-- Automated installation
-- Support for several database types
-- Multiblog
-- Multi-user with permissions
-- Standards compliant
-- Accessible
-- Importing / exporting
-- Naturally optimized for search engines
-- Syndication feeds
-- Complete trackback/pingback/webmention support
-- Full Unicode support
-- Extensible
-- Performance and scalability
-- Twice free
+Dotclear project's purpose is to provide a user-friendly tool allowing anyone to publish on the web, regardless of their technical skills.
 
 
 **Version incluse :** 2.27.3~ynh1

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,6 +16,7 @@ location __PATH__/ {
 
     fastcgi_index index.php;
     include fastcgi_params;
+    fastcgi_param DC_BLOG_ID __BLOG_ID__;
     fastcgi_param REMOTE_USER $remote_user;
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param SCRIPT_FILENAME $request_filename;

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -106,13 +106,23 @@ help = "These permissions apply to the first connection of the user, the super u
 
 [blogs]
 name = "Multiple blogs management"
-help = "Here you can instruct YunoHost to handle multiple blogs. It will create the appropriate permissions and NGINX configuration files. You still need to add them in Dotclear's administration panel. Removing them here will not delete them from Dotclear, and vice-versa."
 
-    [blogs.blogs_list]
-    name = "List of blogs to handle"
+    [blogs.blogs]
+    name = ""
 
-        [blogs.blogs_list.blogs_list]
-        ask = "List blogs with the format `id@domain.example/path`"
+        [blogs.blogs.info]
+        type = "alert"
+        style = "info"
+        ask = "Here you can instruct YunoHost to handle multiple blogs. It will create the appropriate permissions and NGINX configuration files.\n You still need to add them in Dotclear's administration panel. Removing them here will not delete them from Dotclear, and vice-versa."
+
+        [blogs.blogs.blogs_list]
+        ask = "List of blogs"
         type = "tags"
         pattern.regexp = "[\\w]+@[\\w.]+\\/[\\w]*"
         pattern.error = "Incorrect format. Use `id@domain.example/path`"
+        help = """\
+        - The `default` blog cannot be deleted and will be put back in the list. Use the usual Change URL method to move it to a new URL.\n\
+        - Additional blogs must be declared with the format `id@domain.example/path`.
+        Each blog will have two permissions for main and admin access. By default the former has "visitors and all_users" access and the latter has "admins" group access.
+        Keeping the same `id` but changing the domain or path will keep the permission but reset the NGINX configuration file to the new location.
+        """

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -103,3 +103,16 @@ help = "These permissions apply to the first connection of the user, the super u
             yes = "true"
             no = "false"
             bind = "'blogroll':__INSTALL_DIR__/inc/class.auth.ldap.php"
+
+[blogs]
+name = "Multiple blogs management"
+help = "Here you can instruct YunoHost to handle multiple blogs. It will create the appropriate permissions and NGINX configuration files. You still need to add them in Dotclear's administration panel. Removing them here will not delete them from Dotclear, and vice-versa."
+
+    [blogs.blogs_list]
+    name = "List of blogs to handle"
+
+        [blogs.blogs_list.blogs_list]
+        ask = "List blogs with the format `id@domain.example/path`"
+        type = "tags"
+        pattern.regexp = "[\\w]+@[\\w.]+\\/[\\w]*"
+        pattern.error = "Incorrect format. Use `id@domain.example/path`"

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,35 +1,4 @@
 Dotclear is an open-source web publishing software.
 Take control over your blog!
 
-Dotclear project's purpose is to provide a user-friendly
-tool allowing anyone to publish on the web, regardless of their technical skills.
-
-### Features
-
-- Easy publication
-- Fully customizable theme
-- User-friendly administration
-- Flexible template system
-- Media management
-- Choose from several editing syntax (wiki, markdown or directly in wysiwyg)
-- Flexible comment system
-- Built-in antispam
-- Localization
-- Presentation widgets
-- Themes and plugins
-- Pages
-- Tags and categories
-- Automated installation
-- Support for several database types
-- Multiblog
-- Multi-user with permissions
-- Standards compliant
-- Accessible
-- Importing / exporting
-- Naturally optimized for search engines
-- Syndication feeds
-- Complete trackback/pingback/webmention support
-- Full Unicode support
-- Extensible
-- Performance and scalability
-- Twice free
+Dotclear project's purpose is to provide a user-friendly tool allowing anyone to publish on the web, regardless of their technical skills.

--- a/scripts/config
+++ b/scripts/config
@@ -16,6 +16,8 @@ ynh_abort_if_errors
 
 install_dir=$(ynh_app_setting_get --app=$app --key=install_dir)
 admin=$(ynh_app_setting_get --app=$app --key=admin)
+domain=$(ynh_app_setting_get --app=$app --key=domain)
+path=$(ynh_app_setting_get --app=$app --key=path)
 
 #=================================================
 # SPECIFIC SETTERS FOR TOML SHORT KEYS
@@ -25,13 +27,15 @@ set__blogs_list() {
     declare -A domain_array
     declare -A path_array
 
+    default_present=false
     for blog in $(echo $blogs_list | sed "s/,/ /"); do
         id=$(echo $blog | cut -d@ -f1)
-        domain=$(echo $blog | cut -d@ -f2 | cut -d/ -f1)
-        path="/$(echo $blog | cut -d@ -f2 | cut -d/ -f2)"
+        d=$(echo $blog | cut -d@ -f2 | cut -d/ -f1)
+        p="/$(echo $blog | cut -d@ -f2 | cut -d/ -f2)"
+        [ $id = "default" ] && default_present=true
 
-        domain_array+=([$id]=$domain)
-        path_array+=([$id]=$path)
+        domain_array+=([$id]=$d)
+        path_array+=([$id]=$p)
     done
 
     declare -A old_domain_array
@@ -39,43 +43,62 @@ set__blogs_list() {
 
     for blog in $(echo ${old[blogs_list]} | sed "s/,/ /"); do
         id=$(echo $blog | cut -d@ -f1)
-        domain=$(echo $blog | cut -d@ -f2 | cut -d/ -f1)
-        path="/$(echo $blog | cut -d@ -f2 | cut -d/ -f2)"
+        d=$(echo $blog | cut -d@ -f2 | cut -d/ -f1)
+        p="/$(echo $blog | cut -d@ -f2 | cut -d/ -f2)"
 
-        old_domain_array+=([$id]=$domain)
-        old_path_array+=([$id]=$path)
+        old_domain_array+=([$id]=$d)
+        old_path_array+=([$id]=$p)
     done
 
+    # Make sure the default blog is always listed
+    domain_array+=(["default"]=$domain)
+    path_array+=(["default"]=$path)
+    old_domain_array+=(["default"]=$domain)
+    old_path_array+=(["default"]=$path)
+    if [ $default_present = false ]; then
+        if [ -z ${blogs_list:-} ]; then
+            blogs_list="default@$domain$path"
+        else
+            blogs_list+=",default@$domain$path"
+        fi
+    fi
+    
     # https://stackoverflow.com/questions/2312762/compare-difference-of-two-arrays-in-bash
     # Get added and removed blogs
-    added_ids_array=(`echo ${!domain_array[@]} ${!old_domain_array[@]} | tr ' ' '\n' | sort | uniq -u `)
-    removed_ids_array=(`echo ${!old_domain_array[@]} ${!domain_array[@]} | tr ' ' '\n' | sort | uniq -D | uniq `)
+    added_ids_array=()
+    added_ids_array+=(`echo ${!domain_array[@]} ${!old_domain_array[@]} | tr ' ' '\n' | sort | uniq -u `)
+    removed_ids_array=()
+    removed_ids_array+=(`echo ${!domain_array[@]} ${!old_domain_array[@]} | tr ' ' '\n' | sort | uniq -D | uniq `)
 
-    for id in $removed_ids_array; do
-        if [ ynh_permission_exists --permission="$id" ]; then
-            ynh_permission_delete --permission="$id"
+    ynh_print_info --message="Added blogs: ${added_ids_array[@]}"
+    ynh_print_info --message="Removed blogs: ${removed_ids_array[@]}"
+
+    for id in ${removed_ids_array[@]}; do
+        if [ $id != "default" ]; then
+            if ynh_permission_exists --permission="$id"; then
+                ynh_permission_delete --permission="$id"
+            fi
+            ynh_secure_remove --file="/etc/nginx/conf.d/${old_domain_array[$id]}.d/$app-$id.conf"
         fi
-        ynh_secure_remove --file="/etc/nginx/conf.d/${old_domain_array[$id]}.d/$app.conf"
     done
 
-    for id in $domain_array; do
-    
-        if [ $domain_array[$id] != $old_domain_array[$id] ]; then
-            mv /etc/nginx/conf.d/${old_domain_array[$id]}.d/$app.conf /etc/nginx/conf.d/${domain_array[$id]}.d/$app.conf
-        fi
-        
-        if [ $path_array[$id] != $old_path_array[$id] ]; then
-            domain=$domain_array[$id]
-            path=$path_array[$id]
-            ynh_add_config --template="nginx.conf" --destination="/etc/nginx/conf.d/${domain_array[$id]}.d/$app.conf"
-        fi
+    for id in ${!domain_array[@]}; do
+        if [ $id != "default" ]; then
+            if [ ${domain_array[$id]:-} != ${old_domain_array[$id]:-} ] ||
+               [ ${path_array[$id]:-} != ${old_path_array[$id]:-} ]; then
+                domain=${domain_array[$id]}
+                path=${path_array[$id]}
+                [ ! -z ${old_domain_array[$id]:-} ] && ynh_secure_remove --file="/etc/nginx/conf.d/${old_domain_array[$id]}.d/$app-$id.conf"
+                ynh_add_config --template="nginx.conf" --destination="/etc/nginx/conf.d/${domain_array[$id]}.d/$app-$id.conf"
+            fi
 
-        if [ ynh_permission_exists --permission="$id" ]; then
-            ynh_permission_url --permission="$id" --url="$domain_array[$id]$path_array[$id]"
-            ynh_permission_url --permission="${id}-admin" --url="$domain_array[$id]$path_array[$id]/admin"
-        else
-            ynh_permission_create --permission="$id" --url="$domain_array[$id]$path_array[$id]"
-            ynh_permission_create --permission="${id}-admin" --url="$domain_array[$id]$path_array[$id]/admin"
+            if ynh_permission_exists --permission="$id"; then
+                ynh_permission_url --permission="$id" --url="${domain_array[$id]}${path_array[$id]}"
+                ynh_permission_url --permission="${id}-admin" --url="${domain_array[$id]}${path_array[$id]}/admin"
+            else
+                ynh_permission_create --permission="$id" --url="${domain_array[$id]}${path_array[$id]}" --show_tile=true
+                ynh_permission_create --permission="${id}-admin" --url="${domain_array[$id]}${path_array[$id]}/admin" --show_tile=true
+            fi
         fi
         
     done

--- a/scripts/config
+++ b/scripts/config
@@ -18,6 +18,7 @@ install_dir=$(ynh_app_setting_get --app=$app --key=install_dir)
 admin=$(ynh_app_setting_get --app=$app --key=admin)
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path=$(ynh_app_setting_get --app=$app --key=path)
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
 # SPECIFIC SETTERS FOR TOML SHORT KEYS
@@ -77,6 +78,9 @@ set__blogs_list() {
             if ynh_permission_exists --permission="$id"; then
                 ynh_permission_delete --permission="$id"
             fi
+            if ynh_permission_exists --permission="${id}-admin"; then
+                ynh_permission_delete --permission="${id}-admin"
+            fi
             ynh_secure_remove --file="/etc/nginx/conf.d/${old_domain_array[$id]}.d/$app-$id.conf"
         fi
     done
@@ -87,6 +91,7 @@ set__blogs_list() {
                [ "${path_array[$id]:-}" != "${old_path_array[$id]:-}" ]; then
                 domain=${domain_array[$id]}
                 path=${path_array[$id]}
+                blog_id=$id
                 [ ! -z ${old_domain_array[$id]:-} ] && ynh_secure_remove --file="/etc/nginx/conf.d/${old_domain_array[$id]}.d/$app-$id.conf"
                 ynh_add_config --template="nginx.conf" --destination="/etc/nginx/conf.d/${domain_array[$id]}.d/$app-$id.conf"
             fi
@@ -95,8 +100,8 @@ set__blogs_list() {
                 ynh_permission_url --permission="$id" --url="${domain_array[$id]}${path_array[$id]}"
                 ynh_permission_url --permission="${id}-admin" --url="${domain_array[$id]}${path_array[$id]}/admin"
             else
-                ynh_permission_create --permission="$id" --url="${domain_array[$id]}${path_array[$id]}" --show_tile=true
-                ynh_permission_create --permission="${id}-admin" --url="${domain_array[$id]}${path_array[$id]}/admin" --show_tile=true
+                ynh_permission_create --permission="$id" --url="${domain_array[$id]}${path_array[$id]}" --show_tile=true --allowed=visitors all_users
+                ynh_permission_create --permission="${id}-admin" --url="${domain_array[$id]}${path_array[$id]}/admin" --show_tile=false --allowed=admins
             fi
         fi
         

--- a/scripts/config
+++ b/scripts/config
@@ -65,14 +65,13 @@ set__blogs_list() {
     
     # https://stackoverflow.com/questions/2312762/compare-difference-of-two-arrays-in-bash
     # Get added and removed blogs
-    added_ids_array=()
-    added_ids_array+=(`echo ${!domain_array[@]} ${!old_domain_array[@]} | tr ' ' '\n' | sort | uniq -u `)
-    removed_ids_array=()
-    removed_ids_array+=(`echo ${!domain_array[@]} ${!old_domain_array[@]} | tr ' ' '\n' | sort | uniq -D | uniq `)
+    difference_ids_array=(`echo ${!domain_array[@]} ${!old_domain_array[@]} | tr ' ' '\n' | sort | uniq -u `)
+    added_ids_array=(`echo ${!domain_array[@]} ${difference_ids_array[@]} | tr ' ' '\n' | sort | uniq -D | uniq `)
+    removed_ids_array=(`echo ${!old_domain_array[@]} ${difference_ids_array[@]} | tr ' ' '\n' | sort | uniq -D | uniq `)
 
     ynh_print_info --message="Added blogs: ${added_ids_array[@]}"
     ynh_print_info --message="Removed blogs: ${removed_ids_array[@]}"
-
+    
     for id in ${removed_ids_array[@]}; do
         if [ $id != "default" ]; then
             if ynh_permission_exists --permission="$id"; then
@@ -84,8 +83,8 @@ set__blogs_list() {
 
     for id in ${!domain_array[@]}; do
         if [ $id != "default" ]; then
-            if [ ${domain_array[$id]:-} != ${old_domain_array[$id]:-} ] ||
-               [ ${path_array[$id]:-} != ${old_path_array[$id]:-} ]; then
+            if [ "${domain_array[$id]:-}" != "${old_domain_array[$id]:-}" ] ||
+               [ "${path_array[$id]:-}" != "${old_path_array[$id]:-}" ]; then
                 domain=${domain_array[$id]}
                 path=${path_array[$id]}
                 [ ! -z ${old_domain_array[$id]:-} ] && ynh_secure_remove --file="/etc/nginx/conf.d/${old_domain_array[$id]}.d/$app-$id.conf"

--- a/scripts/config
+++ b/scripts/config
@@ -49,7 +49,7 @@ set__blogs_list() {
     # https://stackoverflow.com/questions/2312762/compare-difference-of-two-arrays-in-bash
     # Get added and removed blogs
     added_ids_array=(`echo ${!domain_array[@]} ${!old_domain_array[@]} | tr ' ' '\n' | sort | uniq -u `)
-    removed_ids_array=(`echo ${!old_domain_array[@]} $!domain_array[@]} | tr ' ' '\n' | sort | uniq -D | uniq `)
+    removed_ids_array=(`echo ${!old_domain_array[@]} ${!domain_array[@]} | tr ' ' '\n' | sort | uniq -D | uniq `)
 
     for id in $removed_ids_array; do
         if [ ynh_permission_exists --permission="$id" ]; then
@@ -72,10 +72,10 @@ set__blogs_list() {
 
         if [ ynh_permission_exists --permission="$id" ]; then
             ynh_permission_url --permission="$id" --url="$domain_array[$id]$path_array[$id]"
-            ynh_permission_url --permission="$id.admin" --url="$domain_array[$id]$path_array[$id]/admin"
+            ynh_permission_url --permission="${id}-admin" --url="$domain_array[$id]$path_array[$id]/admin"
         else
             ynh_permission_create --permission="$id" --url="$domain_array[$id]$path_array[$id]"
-            ynh_permission_create --permission="$id.admin" --url="$domain_array[$id]$path_array[$id]/admin"
+            ynh_permission_create --permission="${id}-admin" --url="$domain_array[$id]$path_array[$id]/admin"
         fi
         
     done

--- a/scripts/install
+++ b/scripts/install
@@ -132,7 +132,7 @@ installUrl="/admin/install/index.php"
 ynh_local_curl $installUrl "u_email=$email" "u_firstname=$firstname" "u_name=$lastname" "u_login=$admin" "u_pwd=$password" "u_pwd2=$password"
 
 # Initializing blogs_list (excluding default)
-ynh_app_setting_set --app=$app --key=blogs_list --value=""
+ynh_app_setting_set --app=$app --key=blogs_list --value="default@$domain$path"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/install
+++ b/scripts/install
@@ -131,6 +131,9 @@ installUrl="/admin/install/index.php"
 
 ynh_local_curl $installUrl "u_email=$email" "u_firstname=$firstname" "u_name=$lastname" "u_login=$admin" "u_pwd=$password" "u_pwd2=$password"
 
+# Initializing blogs_list (excluding default)
+ynh_app_setting_set --app=$app --key=blogs_list --value=""
+
 #=================================================
 # GENERIC FINALIZATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -55,6 +55,11 @@ if [ -z "$blog_admin" ] ||
 	ynh_app_setting_set --app=$app --key=blog_blogroll --value=$blog_blogroll
 fi
 
+if [ -z "$blogs_list" ]; then
+    # Initializing blogs_list (excluding default)
+    ynh_app_setting_set --app=$app --key=blogs_list --value=""
+fi
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -57,7 +57,7 @@ fi
 
 if [ -z "$blogs_list" ]; then
     # Initializing blogs_list (excluding default)
-    ynh_app_setting_set --app=$app --key=blogs_list --value=""
+    ynh_app_setting_set --app=$app --key=blogs_list --value="default@$domain$path"
 fi
 
 #=================================================


### PR DESCRIPTION
Adds multiple blogs management by adding a setting for listing domains and paths as tags. This automagically creates the appropriate YunoHost permissions for the app. The user still has to add the blogs ids and configuration within Dotclear.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
